### PR TITLE
fix unnecessary knowledge sync in `TeamImpl`

### DIFF
--- a/src/main/java/io/github/kurrycat2004/peteams/provider/impls/TeamImpl.java
+++ b/src/main/java/io/github/kurrycat2004/peteams/provider/impls/TeamImpl.java
@@ -90,7 +90,7 @@ public class TeamImpl implements ITeamKnowledgeHolder {
 
         boolean knowsItem = this.hasKnowledge(stack);
         boolean isTome = stack.getItem() == ObjHandler.tome;
-        if (knowsItem && isTome) return false;
+        if (knowsItem && !isTome) return false;
 
         if (!knowsItem) {
             PETeams.debugLog("Adding knowledge {} for player {}", stack, playerUUIDSupplier.get());


### PR DESCRIPTION
51cedda9cce69d1cbc6e636dbf92671638d6b4fe fixed `DefaultImpl`, but not `TeamImpl`.